### PR TITLE
Fixed scrollTop on Chrome 61

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -151,7 +151,7 @@ class Back2Top extends Component {
     }
 
     getScrollTop() {
-        return this.isFirefox() ? document.documentElement.scrollTop : document.body.scrollTop;
+        return document.documentElement.scrollTop;
     }
 
     setScrollTop(value) {


### PR DESCRIPTION
On Chrome 61 document.body.scrollTop does not work anymore.
This patch fix the problem.